### PR TITLE
Sort by version

### DIFF
--- a/ConnectExchangeOnPrem/Public/ConnectExchangeServer.ps1
+++ b/ConnectExchangeOnPrem/Public/ConnectExchangeServer.ps1
@@ -6,6 +6,7 @@ Connect to and import a implicit remoting session from an On-Premises Exchange d
 This command makes connection to an On-Premises exchange simple. It is intended to be an On-Premises equivalent of the Connect-ExchangeOnline command.
 
 It will attempt to discover existing exchange servers in the current domain. It will then attempt to connect to each exchange server and import the first sucessful session.
+The search order is determined by the server version, it will try newer exchange servers first.
 
 .PARAMETER ComputerName
 Specify the hostname of the exchange server to connect to.
@@ -24,6 +25,12 @@ Credential to connect to the Exchange server. You should only need this if you c
 Prefix commands from the implicit module with the specified string.
 
 This comes from the module import so will Prefix to the Noun of the command.
+
+.PARAMETER VersionString
+Only connect to servers that have the given admin version.
+The version string is the same format as the admin version from Get-ExchangeServer ie "Version 15.0 (Build 1234.56)"
+
+This parameter supports wildcards so "Version 15.2* will only connect to Exchange 2019 servers."
 
 .EXAMPLE
 Connect-ExchangeOnPrem

--- a/ConnectExchangeOnPrem/Public/ConnectExchangeServer.ps1
+++ b/ConnectExchangeOnPrem/Public/ConnectExchangeServer.ps1
@@ -36,6 +36,13 @@ This parameter supports wildcards so "Version 15.2* will only connect to Exchang
 Connect-ExchangeOnPrem
 
 With no parameters, the command will attempt to lookup a working Exchange server in AD. It will then connect using the default Kerberos authentication.
+
+.EXAMPLE
+Connect-ExchangeOnPrem -VersionString "Version 15.0*"
+
+Lookup server list from AD, but only try to connect to a server who's Admin Version matches the specified version.
+In this example it will only connect to Exchange 2013 servers.
+
 .NOTES
 
 #>


### PR DESCRIPTION
This should hunt newer servers first.

The serial number, while being a string, appears to have a consistent enough pattern to use for sorting. I was unable to find the install version in Ad otherwise. ObjectVersion appears to be increased by date of patch so might pull a patched 2019 before an unpatched 2022. At least this way it would sort by major version first.